### PR TITLE
Fix/structured themes

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+echo "🎬 Compiling Typst Presentate..."
+cd "$(dirname "$0")"
+
+# Docs
+typst compile --root .. assets/manual/themes-guide.typ
+
+# Examples
+for file in assets/examples/*.typ; do
+    [ -f "$file" ] && typst compile --root .. "$file"
+done
+
+# Tests
+for file in assets/tests/*.typ; do
+    [ -f "$file" ] && typst compile --root .. "$file"
+done

--- a/src/components/components.typ
+++ b/src/components/components.typ
@@ -1,4 +1,4 @@
-#import "@preview/navigator:0.1.4": render-miniframes, get-structure, get-current-logical-slide-number, progressive-outline, get-active-headings, resolve-slide-title, is-role, render-transition, navigator-config
+#import "@preview/navigator:0.1.5": render-miniframes, get-structure, get-current-logical-slide-number, progressive-outline, get-active-headings, resolve-slide-title, is-role, render-transition, navigator-config
 #import "structure.typ": structure-config, empty-slide
 #import "title.typ": slide-title
 #import "../store.typ": prefix 

--- a/src/components/components.typ
+++ b/src/components/components.typ
@@ -1,4 +1,4 @@
-#import "@preview/navigator:0.1.3": render-miniframes, get-structure, get-current-logical-slide-number, progressive-outline, get-active-headings, resolve-slide-title, is-role, render-transition, navigator-config
+#import "@preview/navigator:0.1.4": render-miniframes, get-structure, get-current-logical-slide-number, progressive-outline, get-active-headings, resolve-slide-title, is-role, render-transition, navigator-config
 #import "structure.typ": structure-config, empty-slide
 #import "title.typ": slide-title
 #import "../store.typ": prefix 

--- a/src/components/structure.typ
+++ b/src/components/structure.typ
@@ -1,6 +1,6 @@
 #import "../store.typ"
 #import "../presentate.typ" as p
-#import "@preview/navigator:0.1.3" as nav
+#import "@preview/navigator:0.1.4" as nav
 
 // Re-export navigator config
 #let structure-config = nav.navigator-config

--- a/src/components/structure.typ
+++ b/src/components/structure.typ
@@ -1,6 +1,6 @@
 #import "../store.typ"
 #import "../presentate.typ" as p
-#import "@preview/navigator:0.1.4" as nav
+#import "@preview/navigator:0.1.5" as nav
 
 // Re-export navigator config
 #let structure-config = nav.navigator-config

--- a/src/components/title.typ
+++ b/src/components/title.typ
@@ -1,1 +1,1 @@
-#import "@preview/navigator:0.1.4": slide-title
+#import "@preview/navigator:0.1.5": slide-title

--- a/src/components/title.typ
+++ b/src/components/title.typ
@@ -1,1 +1,1 @@
-#import "@preview/navigator:0.1.3": slide-title
+#import "@preview/navigator:0.1.4": slide-title

--- a/src/themes/structured/miniframes.typ
+++ b/src/themes/structured/miniframes.typ
@@ -2,6 +2,7 @@
 #import "../../store.typ": states, set-options
 #import "../../components/components.typ": get-structure, get-current-logical-slide-number, render-miniframes, progressive-outline, get-active-headings, structure-config, resolve-slide-title, is-role, render-transition, navigator-config
 #import "../../components/structure.typ": empty-slide
+#import "shared.typ": apply-heading-numbering, apply-transition-rule
 #import "../../components/title.typ": slide-title
 
 // États pour partager la config entre le template et les fonctions slide
@@ -165,26 +166,7 @@
 
   show heading: set text(size: 1em, weight: "regular")
   
-  // Wrap the document to ensure heading numbering is global and increments counters
-  show: doc => {
-    if show-heading-numbering {
-      if numbering-format != auto {
-        set heading(outlined: true, numbering: (..nums) => {
-          let lvl = nums.pos().len()
-          if lvl in mapping.values() {
-            numbering(numbering-format, ..nums)
-          }
-        })
-        doc
-      } else {
-        set heading(outlined: true)
-        doc
-      }
-    } else {
-      set heading(numbering: none)
-      doc
-    }
-  }
+  show: apply-heading-numbering.with(mapping, show-heading-numbering, numbering-format)
   
   // Title slide
   p.slide[
@@ -228,35 +210,7 @@
     ])
   }
 
-  // Unified Transition Rule
-  show heading: h => {
-    let hook = none
-    if is-role(mapping, h.level, "part") { hook = on-part-change }
-    else if is-role(mapping, h.level, "section") { hook = on-section-change }
-    else if is-role(mapping, h.level, "subsection") { hook = on-subsection-change }
-
-    if hook != none {
-      hook(h)
-    } else {
-      let final-trans = transitions
-      if show-all-sections-in-transition {
-        let all-vis = (part: "all", section: "all", subsection: "all")
-        let override = (parts: (visibility: all-vis), sections: (visibility: all-vis), subsections: (visibility: all-vis))
-        if type(transitions) == dictionary {
-          final-trans = p.utils.merge-dicts(base: transitions, override)
-        } else {
-          final-trans = override
-        }
-      }
-
-      render-transition(
-        h,
-        transitions: final-trans,
-        use-short-title: false,
-        max-length: none,
-      )
-    }
-  }
+  show heading: apply-transition-rule.with(mapping, transitions, show-all-sections-in-transition, on-part-change, on-section-change, on-subsection-change)
 
   set-options(..options)
   body

--- a/src/themes/structured/miniframes.typ
+++ b/src/themes/structured/miniframes.typ
@@ -247,6 +247,7 @@
 
       render-transition(
         h,
+        transitions: final-trans,
         use-short-title: false,
         max-length: none,
       )

--- a/src/themes/structured/miniframes.typ
+++ b/src/themes/structured/miniframes.typ
@@ -24,7 +24,11 @@
   if nav-opts.position == "bottom" { st-inset.insert("top", 1.5em) }
   let st = slide-title(resolve-slide-title(title), size: 1.2em, weight: "bold", inset: st-inset)
 
-  let bar = render-miniframes()
+  let nav-config = navigator-config.get()
+  let sel = nav-config.at("slide-selector", default: metadata.where(value: (t: "Miniframes_Normal")))
+  let s = get-structure(slide-selector: sel, all-shorts: query(<short>))
+  let n = get-current-logical-slide-number(slide-selector: sel)
+  let bar = render-miniframes(s, n)
 
   // Style global de la slide (on force la police/taille du thème)
   set text(weight: "regular", fill: black, size: config.text-size, font: config.text-font)

--- a/src/themes/structured/minimal.typ
+++ b/src/themes/structured/minimal.typ
@@ -186,6 +186,7 @@
 
       render-transition(
         h,
+        transitions: final-trans,
         use-short-title: false,
         max-length: none,
       )

--- a/src/themes/structured/minimal.typ
+++ b/src/themes/structured/minimal.typ
@@ -3,6 +3,7 @@
 #import "../../components/components.typ": progressive-outline, get-active-headings, structure-config, resolve-slide-title, is-role, render-transition, navigator-config
 #import "../../components/structure.typ": empty-slide
 #import "../../components/title.typ": slide-title
+#import "shared.typ": apply-heading-numbering, apply-transition-rule
 
 // State to share configuration between template and slides
 #let config-state = state("minimal-config", none)
@@ -142,56 +143,8 @@
   
   show heading: set text(size: 1em, weight: "regular")
   
-  // Wrap the entire document to ensure heading numbering is global
-  show: doc => {
-    if show-heading-numbering {
-      if numbering-format != auto {
-        set heading(outlined: true, numbering: (..nums) => {
-          let lvl = nums.pos().len()
-          if lvl in mapping.values() {
-            numbering(numbering-format, ..nums)
-          }
-        })
-        doc
-      } else {
-        set heading(outlined: true)
-        doc
-      }
-    } else {
-      set heading(numbering: none)
-      doc
-    }
-  }
-
-  // Unified Transition Rule
-  show heading: h => {
-    let hook = none
-    if is-role(mapping, h.level, "part") { hook = on-part-change }
-    else if is-role(mapping, h.level, "section") { hook = on-section-change }
-    else if is-role(mapping, h.level, "subsection") { hook = on-subsection-change }
-
-    if hook != none {
-      hook(h)
-    } else {
-      let final-trans = transitions
-      if show-all-sections-in-transition {
-        let all-vis = (part: "all", section: "all", subsection: "all")
-        let override = (parts: (visibility: all-vis), sections: (visibility: all-vis), subsections: (visibility: all-vis))
-        if type(transitions) == dictionary {
-          final-trans = p.utils.merge-dicts(base: transitions, override)
-        } else {
-          final-trans = override
-        }
-      }
-
-      render-transition(
-        h,
-        transitions: final-trans,
-        use-short-title: false,
-        max-length: none,
-      )
-    }
-  }
+  show: apply-heading-numbering.with(mapping, show-heading-numbering, numbering-format)
+  show heading: apply-transition-rule.with(mapping, transitions, show-all-sections-in-transition, on-part-change, on-section-change, on-subsection-change)
   
   set-options(..options)
 

--- a/src/themes/structured/progressive-outline.typ
+++ b/src/themes/structured/progressive-outline.typ
@@ -57,9 +57,6 @@
   ..options,
 ) = {
   
-  let trans-opts = (enabled: true, level: 2)
-  if type(transitions) == dictionary { trans-opts = p.utils.merge-dicts(base: trans-opts, transitions) }
-
   // Synchronisation avec navigator-config
   navigator-config.update(c => {
     c.mapping = mapping

--- a/src/themes/structured/progressive-outline.typ
+++ b/src/themes/structured/progressive-outline.typ
@@ -3,6 +3,7 @@
 #import "../../components/components.typ": progressive-outline, get-active-headings, structure-config, resolve-slide-title, is-role, render-transition, navigator-config
 #import "../../components/structure.typ": empty-slide
 #import "../../components/title.typ": slide-title
+#import "shared.typ": apply-heading-numbering, apply-transition-rule
 
 #let config-state = state("progressive-outline-config", none)
 
@@ -119,51 +120,8 @@
   
   show heading: set text(size: 1em, weight: "regular")
   
-  // Wrap the document to ensure heading numbering is global
-  show: doc => {
-    if show-heading-numbering {
-      if numbering-format != auto {
-        set heading(outlined: true, numbering: (..nums) => {
-          let lvl = nums.pos().len()
-          if lvl in mapping.values() {
-            numbering(numbering-format, ..nums)
-          }
-        })
-        doc
-      } else {
-        set heading(outlined: true)
-        doc
-      }
-    } else {
-      set heading(numbering: none)
-      doc
-    }
-  }
-  
-  // Unified Transition Rule
-  show heading: h => {
-    let hook = none
-    if is-role(mapping, h.level, "part") { hook = on-part-change }
-    else if is-role(mapping, h.level, "section") { hook = on-section-change }
-    else if is-role(mapping, h.level, "subsection") { hook = on-subsection-change }
-
-    if hook != none {
-      hook(h)
-    } else {
-      let final-trans = transitions
-      if show-all-sections-in-transition {
-        let all-vis = (part: "all", section: "all", subsection: "all")
-        let override = (parts: (visibility: all-vis), sections: (visibility: all-vis), subsections: (visibility: all-vis))
-        if type(transitions) == dictionary {
-          final-trans = p.utils.merge-dicts(base: final-trans, override)
-        } else {
-          final-trans = override
-        }
-      }
-
-      render-transition(h, transitions: final-trans, use-short-title: false, max-length: none)
-    }
-  }
+  show: apply-heading-numbering.with(mapping, show-heading-numbering, numbering-format)
+  show heading: apply-transition-rule.with(mapping, transitions, show-all-sections-in-transition, on-part-change, on-section-change, on-subsection-change)
 
   // --- Title Slide ---
   empty-slide(text-size: text-size, text-font: text-font, {

--- a/src/themes/structured/progressive-outline.typ
+++ b/src/themes/structured/progressive-outline.typ
@@ -164,7 +164,7 @@
         }
       }
 
-      render-transition(h, use-short-title: false, max-length: none)
+      render-transition(h, transitions: final-trans, use-short-title: false, max-length: none)
     }
   }
 

--- a/src/themes/structured/shared.typ
+++ b/src/themes/structured/shared.typ
@@ -1,0 +1,57 @@
+#import "../../components/components.typ": is-role, render-transition
+#import "../../presentate.typ" as p
+
+/// Applies heading numbering rules to the document.
+/// Usage: show: apply-heading-numbering.with(mapping, show-heading-numbering, numbering-format)
+#let apply-heading-numbering(mapping, show-heading-numbering, numbering-format, doc) = {
+  if show-heading-numbering {
+    if numbering-format != auto {
+      set heading(outlined: true, numbering: (..nums) => {
+        let lvl = nums.pos().len()
+        if lvl in mapping.values() {
+          numbering(numbering-format, ..nums)
+        }
+      })
+      doc
+    } else {
+      set heading(outlined: true)
+      doc
+    }
+  } else {
+    set heading(numbering: none)
+    doc
+  }
+}
+
+/// Applies the unified transition rule to headings.
+/// Usage: show heading: apply-transition-rule.with(mapping, transitions, show-all-sections-in-transition, on-part-change, on-section-change, on-subsection-change)
+#let apply-transition-rule(
+  mapping,
+  transitions,
+  show-all-sections-in-transition,
+  on-part-change,
+  on-section-change,
+  on-subsection-change,
+  h,
+) = {
+  let hook = none
+  if is-role(mapping, h.level, "part") { hook = on-part-change }
+  else if is-role(mapping, h.level, "section") { hook = on-section-change }
+  else if is-role(mapping, h.level, "subsection") { hook = on-subsection-change }
+
+  if hook != none {
+    hook(h)
+  } else {
+    let final-trans = transitions
+    if show-all-sections-in-transition {
+      let all-vis = (part: "all", section: "all", subsection: "all")
+      let override = (parts: (visibility: all-vis), sections: (visibility: all-vis), subsections: (visibility: all-vis))
+      if type(transitions) == dictionary {
+        final-trans = p.utils.merge-dicts(base: transitions, override)
+      } else {
+        final-trans = override
+      }
+    }
+    render-transition(h, transitions: final-trans, use-short-title: false, max-length: none)
+  }
+}

--- a/src/themes/structured/sidebar.typ
+++ b/src/themes/structured/sidebar.typ
@@ -68,9 +68,6 @@
   ..options
 ) = {
   
-  let trans-opts = (enabled: true, level: 2)
-  if type(transitions) == dictionary { trans-opts = p.utils.merge-dicts(base: trans-opts, transitions) }
-
   // Synchronisation avec navigator-config
   navigator-config.update(c => {
     c.mapping = mapping

--- a/src/themes/structured/sidebar.typ
+++ b/src/themes/structured/sidebar.typ
@@ -230,6 +230,7 @@
 
       render-transition(
         h,
+        transitions: final-trans,
         use-short-title: false,
         max-length: none,
       )

--- a/src/themes/structured/sidebar.typ
+++ b/src/themes/structured/sidebar.typ
@@ -1,5 +1,6 @@
 #import "../../presentate.typ" as p
 #import "../../components/components.typ": progressive-outline, get-active-headings, structure-config, resolve-slide-title, is-role, render-transition, navigator-config
+#import "shared.typ": apply-heading-numbering, apply-transition-rule
 #import "../../components/structure.typ": empty-slide
 #import "../../components/title.typ": slide-title
 
@@ -183,56 +184,8 @@
   
   show heading: set text(size: 1em, weight: "regular")
   
-  // Wrap the document to ensure heading numbering is global
-  show: doc => {
-    if show-heading-numbering {
-      if numbering-format != auto {
-        set heading(outlined: true, numbering: (..nums) => {
-          let lvl = nums.pos().len()
-          if lvl in mapping.values() {
-            numbering(numbering-format, ..nums)
-          }
-        })
-        doc
-      } else {
-        set heading(outlined: true)
-        doc
-      }
-    } else {
-      set heading(numbering: none)
-      doc
-    }
-  }
-
-  // Unified Transition Rule
-  show heading: h => {
-    let hook = none
-    if is-role(mapping, h.level, "part") { hook = on-part-change }
-    else if is-role(mapping, h.level, "section") { hook = on-section-change }
-    else if is-role(mapping, h.level, "subsection") { hook = on-subsection-change }
-
-    if hook != none {
-      hook(h)
-    } else {
-      let final-trans = transitions
-      if show-all-sections-in-transition {
-        let all-vis = (part: "all", section: "all", subsection: "all")
-        let override = (parts: (visibility: all-vis), sections: (visibility: all-vis), subsections: (visibility: all-vis))
-        if type(transitions) == dictionary {
-          final-trans = p.utils.merge-dicts(base: transitions, override)
-        } else {
-          final-trans = override
-        }
-      }
-
-      render-transition(
-        h,
-        transitions: final-trans,
-        use-short-title: false,
-        max-length: none,
-      )
-    }
-  }
+  show: apply-heading-numbering.with(mapping, show-heading-numbering, numbering-format)
+  show heading: apply-transition-rule.with(mapping, transitions, show-all-sections-in-transition, on-part-change, on-section-change, on-subsection-change)
 
   // --- Title Slide ---
   empty-slide(fill: sidebar-color, text-size: text-size, text-font: text-font, {

--- a/src/themes/structured/split.typ
+++ b/src/themes/structured/split.typ
@@ -3,6 +3,7 @@
 #import "../../components/components.typ": progressive-outline, get-active-headings, structure-config, resolve-slide-title, is-role, render-transition, navigator-config
 #import "../../components/structure.typ": empty-slide
 #import "../../components/title.typ": slide-title
+#import "shared.typ": apply-heading-numbering, apply-transition-rule
 
 // State to share configuration
 #let config-state = state("split-config", none)
@@ -184,56 +185,8 @@
 
   show heading: set text(size: 1em, weight: "regular")
   
-  // Wrap the document to ensure heading numbering is global
-  show: doc => {
-    if show-heading-numbering {
-      if numbering-format != auto {
-        set heading(outlined: true, numbering: (..nums) => {
-          let lvl = nums.pos().len()
-          if lvl in mapping.values() {
-            numbering(numbering-format, ..nums)
-          }
-        })
-        doc
-      } else {
-        set heading(outlined: true)
-        doc
-      }
-    } else {
-      set heading(numbering: none)
-      doc
-    }
-  }
-  
-  // Unified Transition Rule
-  show heading: h => {
-    let hook = none
-      if is-role(mapping, h.level, "part") { hook = on-part-change }
-      else if is-role(mapping, h.level, "section") { hook = on-section-change }
-      else if is-role(mapping, h.level, "subsection") { hook = on-subsection-change }
-
-      if hook != none {
-        hook(h)
-      } else {
-        let final-trans = transitions
-        if show-all-sections-in-transition {
-          let all-vis = (part: "all", section: "all", subsection: "all")
-          let override = (parts: (visibility: all-vis), sections: (visibility: all-vis), subsections: (visibility: all-vis))
-          if type(transitions) == dictionary {
-            final-trans = p.utils.merge-dicts(base: transitions, override)
-          } else {
-            final-trans = override
-          }
-        }
-
-        render-transition(
-          h,
-          transitions: final-trans,
-          use-short-title: false,
-          max-length: none,
-        )
-      }
-    }
+  show: apply-heading-numbering.with(mapping, show-heading-numbering, numbering-format)
+  show heading: apply-transition-rule.with(mapping, transitions, show-all-sections-in-transition, on-part-change, on-section-change, on-subsection-change)
 
   // --- Title Slide ---
   empty-slide(fill: primary, text-size: text-size, text-font: text-font, {

--- a/src/themes/structured/split.typ
+++ b/src/themes/structured/split.typ
@@ -143,9 +143,6 @@
   body,
   ..options,
 ) = {
-  let trans-opts = (enabled: true, level: 2)
-  if type(transitions) == dictionary { trans-opts = p.utils.merge-dicts(base: trans-opts, transitions) }
-
   // Synchronisation avec navigator-config
   navigator-config.update(c => {
     c.mapping = mapping

--- a/src/themes/structured/split.typ
+++ b/src/themes/structured/split.typ
@@ -231,6 +231,7 @@
 
         render-transition(
           h,
+          transitions: final-trans,
           use-short-title: false,
           max-length: none,
         )


### PR DESCRIPTION
Hi pacaunt,

Following up on our previous exchanges, here's a small set of fixes and cleanups I found while integrating navigator 0.1.4 into the structured themes. The main one is a bug where final-trans was computed but never actually passed to render-transition, so show-all-sections-in-transition was silently ignored in all 5 themes. I also took the opportunity to remove some dead code and extract the duplicated heading/transition rules into a shared file.

All 8 test files compile cleanly. Happy to adjust anything if needed!

David